### PR TITLE
Frontend admin page error handling

### DIFF
--- a/client/src/components/AddAdminModel/AddAdminModal.jsx
+++ b/client/src/components/AddAdminModel/AddAdminModal.jsx
@@ -28,10 +28,12 @@ export default function AddAdminModal({ open, close, submit, errorMessage, setEr
         <div className={cx('error', { hidden: !errorMessage })}>
           {errorMessage}
         </div>
-        Admin Name
-        <input name="name" {...register('name')} placeholder="Admin Name" />
-        Admin Email
-        <input name="email" {...register('email')} placeholder="Admin Email" />
+        <div className={cx('input-group')}>
+          Admin Name
+          <input name="name" {...register('name')} placeholder="Admin Name" />
+          Admin Email
+          <input name="email" {...register('email')} placeholder="Admin Email" />
+        </div>
         <button onClick={handleSubmit(onSubmit)} className={cx('saveButton')} type="button">Save</button>
         <button onClick={() => {close(false); setErrorMessage(null);}} className={cx('cancelButton')} type="button">Cancel</button>
       </form>

--- a/client/src/components/AddAdminModel/AddAdminModal.jsx
+++ b/client/src/components/AddAdminModel/AddAdminModal.jsx
@@ -8,25 +8,32 @@ import classNames from 'classnames/bind';
 
 const cx = classNames.bind(styles);
 
-export default function AddAdminModal({ open, close, submit }) {
+export default function AddAdminModal({ open, close, submit, errorMessage, setErrorMessage }) {
   const { register, handleSubmit } = useForm();
   const onSubmit = (data) => {
-    // console.log(data);
-    submit(data);
-    close(false);
+    submit(data).then((result) => {
+      console.log(result);
+      if (result){
+        close(false);
+        setErrorMessage(null)
+      }
+    });
   };
 
   return (
     <Modal open={open} onClose={() => close(false)}>
       <form className={cx('addAdminForm')} onSubmit={handleSubmit(onSubmit)}>
-        <Close onClick={() => close(false)} className={cx('closeButton')} type="button" />
+        <Close onClick={() => {close(false); setErrorMessage(null);}} className={cx('closeButton')} type="button" />
         <h4>Add Admin</h4>
+        <div className={cx('error', { hidden: !errorMessage })}>
+          {errorMessage}
+        </div>
         Admin Name
         <input name="name" {...register('name')} placeholder="Admin Name" />
         Admin Email
         <input name="email" {...register('email')} placeholder="Admin Email" />
         <button onClick={handleSubmit(onSubmit)} className={cx('saveButton')} type="button">Save</button>
-        <button onClick={() => close(false)} className={cx('cancelButton')} type="button">Cancel</button>
+        <button onClick={() => {close(false); setErrorMessage(null);}} className={cx('cancelButton')} type="button">Cancel</button>
       </form>
     </Modal>
   );
@@ -36,4 +43,11 @@ AddAdminModal.propTypes = {
   open: PropTypes.bool.isRequired,
   close: PropTypes.func.isRequired,
   submit: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string,
+  setErrorMessage: PropTypes.func,
+};
+
+AddAdminModal.defaultProps = {
+  errorMessage: null,
+  setErrorMessage: null,
 };

--- a/client/src/components/AddAdminModel/AddAdminModal.module.scss
+++ b/client/src/components/AddAdminModel/AddAdminModal.module.scss
@@ -43,6 +43,38 @@
         padding: 8px 30px;
         margin: 5px;
     }
+
+    .error {
+        color: $red;
+        font-size: .6em;
+        margin-bottom: .25em;
+    
+        &.hidden {
+          display: none;
+        }
+    
+        &:not(.hidden) + .input-group > input,
+        & + .input-group > input:invalid {
+          box-shadow: inset 0 0 0 2.5px $red;
+        }
+      }
+
+      input {
+        background: none;
+        border: none;
+        outline: none;
+        border-radius: 3px;
+        box-shadow: inset 0 0 0 1.5px $dark-gray;
+        padding: 0.3em 0.3em;
+        font-family: inherit;
+        font-size: 0.75em;
+        transition: box-shadow .15s;
+    
+        &:focus {
+          box-shadow: inset 0 0 0 1.5px $light-blue;
+        }
+      }
+    
 }
 
 

--- a/client/src/components/AddAdminModel/AddAdminModal.module.scss
+++ b/client/src/components/AddAdminModel/AddAdminModal.module.scss
@@ -73,7 +73,7 @@
         &:focus {
           box-shadow: inset 0 0 0 1.5px $light-blue;
         }
-      }
+    }
     
 }
 

--- a/client/src/components/AddAdminModel/AddAdminModal.module.scss
+++ b/client/src/components/AddAdminModel/AddAdminModal.module.scss
@@ -18,6 +18,7 @@
         border:none ;
         font-weight: bold;
         color: white;
+        width: 110px;
     }
     .saveButton {
         background-color: #DC9766;
@@ -25,6 +26,7 @@
         border:none;
         font-weight: bold;
         color: white;
+        width: 110px;
     }
 
     input {
@@ -41,7 +43,7 @@
     button {
         float: right;
         padding: 8px 30px;
-        margin: 5px;
+        margin: 5px 0px 0px 5px;
     }
 
     .error {

--- a/client/src/components/AddAdminModel/AddAdminModal.module.scss
+++ b/client/src/components/AddAdminModel/AddAdminModal.module.scss
@@ -29,7 +29,8 @@
 
     input {
         width: 100%;
-        margin-bottom: 10px;
+        margin-bottom: 5px;
+        margin-top: 5px;
         padding: 4px;
     }
     

--- a/client/src/components/DeleteAdminModal/DeleteAdminModal.jsx
+++ b/client/src/components/DeleteAdminModal/DeleteAdminModal.jsx
@@ -19,7 +19,7 @@ export default function DeleteAdminModal({ open, close, user, submit }) {
       <form className={cx('deleteAdminForm')} onSubmit={handleSubmit(onSubmit)}>
         <Close onClick={() => close(false)} className={cx('closeButton')} type="button" />
         <h4>Delete Admin</h4>
-        <div>Are you sure that you would like to delete this admin?</div>
+        <div>Are you sure that you would like to delete {user.name}?</div>
         <div className={cx('buttonContainer')}>
           <button onClick={handleSubmit(onSubmit)} className={cx('saveButton')} type="button">Yes</button>
           <button onClick={() => close(false)} className={cx('cancelButton')} type="button">Cancel</button>

--- a/client/src/components/DeleteAdminModal/DeleteAdminModal.module.scss
+++ b/client/src/components/DeleteAdminModal/DeleteAdminModal.module.scss
@@ -18,6 +18,7 @@
         border:none ;
         font-weight: bold;
         color: white;
+        width: 110px;
     }
     .saveButton {
         background-color: #DC9766;
@@ -25,6 +26,7 @@
         border:none;
         font-weight: bold;
         color: white;
+        width: 110px;
     }
     .buttonContainer {
         display: inline;
@@ -43,7 +45,7 @@
     button {
         float: right;
         padding: 8px 30px;
-        margin: 5px;
+        margin: 5px 0px 0px 5px;
     }
 }
 

--- a/client/src/components/EditAdminModal/EditAdminModal.jsx
+++ b/client/src/components/EditAdminModal/EditAdminModal.jsx
@@ -44,9 +44,9 @@ export default function EditAdminModal({ open, close, user, submit, errorMessage
           <input name="name" {...register('name')} />
           Admin Email
           <input name="email" {...register('email')} />
+          <button onClick={handleSubmit(onSubmit)} className={cx('saveButton')} type="button">Save</button>
+          <button onClick={() => { close(false); setErrorMessage(null); }} className={cx('cancelButton')} type="button">Cancel</button>
         </div>
-        <button onClick={handleSubmit(onSubmit)} className={cx('saveButton')} type="button">Save</button>
-        <button onClick={() => { close(false); setErrorMessage(null); }} className={cx('cancelButton')} type="button">Cancel</button>
       </form>
     </Modal>
   );

--- a/client/src/components/EditAdminModal/EditAdminModal.jsx
+++ b/client/src/components/EditAdminModal/EditAdminModal.jsx
@@ -8,7 +8,7 @@ import classNames from 'classnames/bind';
 
 const cx = classNames.bind(styles);
 
-export default function EditAdminModal({ open, close, user, submit }) {
+export default function EditAdminModal({ open, close, user, submit, errorMessage, setErrorMessage }) {
   const { register, handleSubmit, setValue } = useForm();
 
   useEffect(() => {
@@ -22,21 +22,31 @@ export default function EditAdminModal({ open, close, user, submit }) {
   }, [user]);
 
   const onSubmit = (data) => {
-    submit(user, data);
-    close(false);
+    submit(user, data).then((result) => {
+      console.log(result);
+      if (result) {
+        close(false);
+        setErrorMessage(null);
+      }
+    });
   };
 
   return (
     <Modal open={open} onClose={() => close(false)}>
       <form className={cx('editAdminForm')} onSubmit={handleSubmit(onSubmit)}>
-        <Close onClick={() => close(false)} className={cx('closeButton')} type="button" />
+        <Close onClick={() => { close(false); setErrorMessage(null); }} className={cx('closeButton')} type="button" />
         <h4>Edit Admin</h4>
-        Admin Name
-        <input name="name" {...register('name')} />
-        Admin Email
-        <input name="email" {...register('email')} />
+        <div className={cx('error', { hidden: !errorMessage })}>
+          {errorMessage}
+        </div>
+        <div className={cx('input-group')}>
+          Admin Name
+          <input name="name" {...register('name')} />
+          Admin Email
+          <input name="email" {...register('email')} />
+        </div>
         <button onClick={handleSubmit(onSubmit)} className={cx('saveButton')} type="button">Save</button>
-        <button onClick={() => close(false)} className={cx('cancelButton')} type="button">Cancel</button>
+        <button onClick={() => { close(false); setErrorMessage(null); }} className={cx('cancelButton')} type="button">Cancel</button>
       </form>
     </Modal>
   );
@@ -51,8 +61,12 @@ EditAdminModal.propTypes = {
     user_id: PropTypes.string.isRequired,
   }),
   submit: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string,
+  setErrorMessage: PropTypes.func
 };
 
 EditAdminModal.defaultProps = {
   user: null,
+  errorMessage: null,
+  setErrorMessage: null
 };

--- a/client/src/components/EditAdminModal/EditAdminModal.module.scss
+++ b/client/src/components/EditAdminModal/EditAdminModal.module.scss
@@ -42,6 +42,37 @@
         padding: 8px 30px;
         margin: 5px;
     }
+
+    .error {
+        color: $red;
+        font-size: .6em;
+        margin-bottom: .25em;
+    
+        &.hidden {
+          display: none;
+        }
+    
+        &:not(.hidden) + .input-group > input,
+        & + .input-group > input:invalid {
+          box-shadow: inset 0 0 0 2.5px $red;
+        }
+      }
+
+      input {
+        background: none;
+        border: none;
+        outline: none;
+        border-radius: 3px;
+        box-shadow: inset 0 0 0 1.5px $dark-gray;
+        padding: 0.3em 0.3em;
+        font-family: inherit;
+        font-size: 0.75em;
+        transition: box-shadow .15s;
+    
+        &:focus {
+          box-shadow: inset 0 0 0 1.5px $light-blue;
+        }
+    }
 }
 
 

--- a/client/src/components/EditAdminModal/EditAdminModal.module.scss
+++ b/client/src/components/EditAdminModal/EditAdminModal.module.scss
@@ -18,6 +18,7 @@
         border:none ;
         font-weight: bold;
         color: white;
+        width: 110px;
     }
     .saveButton {
         background-color: #DC9766;
@@ -25,6 +26,7 @@
         border:none;
         font-weight: bold;
         color: white;
+        width: 110px;
     }
 
     input {
@@ -40,7 +42,7 @@
     button {
         float: right;
         padding: 8px 30px;
-        margin: 5px;
+        margin: 5px 0px 0px 5px;
     }
 
     .error {

--- a/client/src/pages/admin/manager.jsx
+++ b/client/src/pages/admin/manager.jsx
@@ -39,13 +39,13 @@ export default function AdminManager({ blocked }) {
     try {
       const responsePost = await api.post('admins', undefined, data);
       if (responsePost.statusCode == 400) {
-        setaddAdminErrorrMessage(responsePost.message);
+        setaddAdminErrorrMessage('* Invalid email address or admin name');
         return false;
       }
       setaddAdminErrorrMessage(null);
       return true;
     } catch (err) {
-      setaddAdminErrorrMessage('Invalid admin name or email address: ', error);
+      setaddAdminErrorrMessage('* Invalid email address or admin name');
       return false;
     }
   };

--- a/client/src/pages/admin/manager.jsx
+++ b/client/src/pages/admin/manager.jsx
@@ -23,6 +23,7 @@ export default function AdminManager({ blocked }) {
   const [openDeleteAdminModal, setopenDeleteAdminModal] = useState(false);
   const [userToEdit, setuserToEdit] = useState(null);
   const [userToDelete, setuserToDelete] = useState(null);
+  const [addAdminErrorMessage, setaddAdminErrorrMessage] = useState(null);
 
   const handleEditClick = (user) => {
     setopenEditAdminModal(true);
@@ -34,34 +35,30 @@ export default function AdminManager({ blocked }) {
     setuserToDelete(user);
   };
 
-  const addUser = (data) => {
-    api.post('admins', undefined, data)
-      .then((responsePost) => {
-        // console.log(responsePost);
-        api.get('admins').then((responseGet) => {
-          setAdmins(responseGet);
-        }).catch((error) => {
-          console.error(error);
-        });
-      })
-      .catch((error) => {
-        // console.log(error);
-      });
+  const addUser = async (data) => {
+    try {
+      const responsePost = await api.post('admins', undefined, data);
+      if (responsePost.statusCode == 400) {
+        setaddAdminErrorrMessage(responsePost.message);
+        return false;
+      }
+      setaddAdminErrorrMessage(null);
+      return true;
+    } catch (err) {
+      setaddAdminErrorrMessage('Invalid admin name or email address: ', error);
+      return false;
+    }
   };
 
   const editUser = (currUser, data) => {
     const id = (currUser.user_id.split('|'))[1];
     api.put(`admins/${id}`, undefined, data)
       .then(() => {
-        // console.log(responsePut);
-        api.get('admins').then((responseGet) => {
-          setAdmins(responseGet);
-        }).catch((error) => {
-          console.error(error);
-        });
+        return true;
       })
       .catch((error) => {
         console.error(error);
+        return false;
       });
   };
 
@@ -69,15 +66,11 @@ export default function AdminManager({ blocked }) {
     const id = (currUser.user_id.split('|'))[1];
     api.delete(`admins/${id}`)
       .then(() => {
-        // console.log(responseDelete);
-        api.get('admins').then((responseGet) => {
-          setAdmins(responseGet);
-        }).catch((error) => {
-          console.error(error);
-        });
+        return true;
       })
       .catch((error) => {
         console.error(error);
+        return false;
       });
   };
 
@@ -90,7 +83,7 @@ export default function AdminManager({ blocked }) {
         console.error(error);
       });
     }
-  }, [api, api.authenticated]);
+  }, [api.authenticated, admins]);
 
   const adminList = () => {
     if (!adminsLoaded) {
@@ -112,6 +105,8 @@ export default function AdminManager({ blocked }) {
         open={openAddAdminModal}
         close={setopenAddAdminModal}
         submit={addUser}
+        errorMessage={addAdminErrorMessage}
+        setErrorMessage={setaddAdminErrorrMessage}
       />
       <EditAdminModal
         open={openEditAdminModal}

--- a/client/src/pages/admin/manager.jsx
+++ b/client/src/pages/admin/manager.jsx
@@ -94,8 +94,8 @@ export default function AdminManager({ blocked }) {
         <input className={cx('adminName')} type="text" readOnly value={user.name} />
         <div className={cx('verticalBreak')} />
         <input className={cx('adminEmail')} type="text" readOnly value={user.email} />
-        <Pen className={cx('penIcon')} type="button" onClick={() => handleEditClick(user)} />
         <Trash className={cx('trashIcon')} type="button" onClick={() => handleDeleteClick(user)} />
+        <Pen className={cx('penIcon')} type="button" onClick={() => handleEditClick(user)} />
       </div>
     ));
   };

--- a/client/src/pages/admin/manager.jsx
+++ b/client/src/pages/admin/manager.jsx
@@ -23,7 +23,7 @@ export default function AdminManager({ blocked }) {
   const [openDeleteAdminModal, setopenDeleteAdminModal] = useState(false);
   const [userToEdit, setuserToEdit] = useState(null);
   const [userToDelete, setuserToDelete] = useState(null);
-  const [addAdminErrorMessage, setaddAdminErrorrMessage] = useState(null);
+  const [errorMessage, setErrorrMessage] = useState(null);
 
   const handleEditClick = (user) => {
     setopenEditAdminModal(true);
@@ -39,27 +39,32 @@ export default function AdminManager({ blocked }) {
     try {
       const responsePost = await api.post('admins', undefined, data);
       if (responsePost.statusCode == 400) {
-        setaddAdminErrorrMessage('* Invalid email address or admin name');
+        setErrorrMessage('* Invalid email address or admin name');
         return false;
       }
-      setaddAdminErrorrMessage(null);
+      setErrorrMessage(null);
       return true;
     } catch (err) {
-      setaddAdminErrorrMessage('* Invalid email address or admin name');
+      setErrorrMessage('* Invalid email address or admin name');
       return false;
     }
   };
 
-  const editUser = (currUser, data) => {
+  const editUser =  async (currUser, data) => {
     const id = (currUser.user_id.split('|'))[1];
-    api.put(`admins/${id}`, undefined, data)
-      .then(() => {
-        return true;
-      })
-      .catch((error) => {
-        console.error(error);
+    try {
+      const responsePut = await api.put(`admins/${id}`, undefined, data);
+      console.log(responsePut);
+      if (responsePut.statusCode === 400) {
+        setErrorrMessage('* Invalid email address or admin name');
         return false;
-      });
+      }
+      setErrorrMessage(null);
+        return true;
+      } catch (err) {
+        setErrorrMessage('* Invalid email address or admin name');
+        return false;
+      }
   };
 
   const deleteUser = (currUser) => {
@@ -105,14 +110,16 @@ export default function AdminManager({ blocked }) {
         open={openAddAdminModal}
         close={setopenAddAdminModal}
         submit={addUser}
-        errorMessage={addAdminErrorMessage}
-        setErrorMessage={setaddAdminErrorrMessage}
+        errorMessage={errorMessage}
+        setErrorMessage={setErrorrMessage}
       />
       <EditAdminModal
         open={openEditAdminModal}
         close={setopenEditAdminModal}
         user={userToEdit}
         submit={editUser}
+        errorMessage={errorMessage}
+        setErrorMessage={setErrorrMessage}
       />
       <DeleteAdminModal
         open={openDeleteAdminModal}

--- a/client/src/pages/admin/manager.module.scss
+++ b/client/src/pages/admin/manager.module.scss
@@ -53,7 +53,7 @@
 
 .mainAdminContainer {
   height: 100%;
-  margin: 2em 8em 2em 8em;
+  margin: 2em 4em 2em 4em;
 
   .buttonContainer {
     display: inline-block;
@@ -98,10 +98,10 @@
   }
 
   input {
-    width: 45%;
+    width: 40%;
     border: none;
     font-size: 75%;
-    padding-left: 15px;
+    padding-left: 10px;
   }
 
   input:focus {
@@ -130,6 +130,21 @@
     width: 28px;
     vertical-align: top;
     fill: #DC9766;
+  }
+
+  .penIcon, .trashIcon {
+    float: right;
+  }
+
+  @media only screen and (max-width: 550px) {
+    .verticalBreak, .adminEmail {
+      display: none;
+    }
+
+    input {
+      width: 60%;
+    }
+
   }
 
 }

--- a/client/src/pages/admin/manager.module.scss
+++ b/client/src/pages/admin/manager.module.scss
@@ -121,7 +121,7 @@
     display: inline;
     border: 1px solid rgb(58, 56, 56, 0.3);
     transform: rotate(90deg);
-    background-color: rgb(58, 56, 56, 0.5);
+    background-color: rgb(58, 56, 56, 0.3);
   }
 
   svg {


### PR DESCRIPTION
## Frontend Admin Page Error Handling

### Summary
- Added error messages and styling for invalid input for username and email addresses when editing and adding new admins
- Made styling and format changes
- Added responsiveness to admin page and admin list
- Fixed 429 Too Many Requests error coming from `useEffect` hook

### Notes
- There is currently no error handling with deleteAdmin modal. It is unclear if we will need it.