### PR TITLE
Backend put handle images

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -64,7 +64,6 @@ class ResourceSerializer(serializers.ModelSerializer):
         
         # CREATE NEW LOCATION CASE
         if location_instance == None and not location_validated_data_empty:
-            print("in create new loction case")
             location_serializer = self.fields['location']
             location_validated_data['resource'] = resource
             locations = location_serializer.create(location_validated_data)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -349,7 +349,7 @@ class ResourceRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
         return response
 
     def update(self, request, *args, **kwargs):
-
+        resource = get_object_or_404(Resource, pk=kwargs['id'])
         # All unrequired fields are populated with None values if empty
         defaultOptionalVals = { 'flyer': None, 'meetingLink': None, 'location': {}, 'flyerId': None, 'startDate': None, 'endDate': None, 'link': None, 'startTime': None, 'endTime': None, 'phone': None, 'email': None, 'isRecurring': None, 'recurrenceDays': [] }
 
@@ -377,12 +377,12 @@ class ResourceRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
                 
                 if image != None:
                     image = cloudinary_url(image)
-                    request.data['flyer'] = image["url"]
+                    request.data['flyer'] = image["secure_url"]
                     request.data['flyerId'] = image["public_id"]
 
         # Delete image
-        if not request.data['flyer'] and request.data['flyerId']:
-            cloudinary_delete(request.data['flyerId'])
+        if not request.data['flyer'] and resource['flyerId']:
+            cloudinary_delete(resource['flyerId'])
             request.data['flyerId'] = ''
             request.data['flyer'] = ''
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -380,11 +380,11 @@ class ResourceRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
                     request.data['flyer'] = image["url"]
                     request.data['flyerId'] = image["public_id"]
 
-            # Delete image
-            if not request.data['flyer'] and flyerId:
-                cloudinary_delete(request.data['flyerId'])
-                request.data['flyerId'] = ''
-                request.data['flyer'] = ''
+        # Delete image
+        if not request.data['flyer'] and request.data['flyerId']:
+            cloudinary_delete(request.data['flyerId'])
+            request.data['flyerId'] = ''
+            request.data['flyer'] = ''
 
         else:
             vErrors = inputValidator(request.data)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -360,13 +360,8 @@ class ResourceRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
             dataURLPattern = r"data:.+;base64,"
             correctDataURLStart = 'data:image'
             isbase64 = re.match(dataURLPattern, request.data['flyer']) and correctDataURLStart == request.data['flyer'][:len(correctDataURLStart)]
-
-            if not isbase64:
-                image_data = request.data.pop('flyer')
-                vErrors = inputValidator(request.data)
-                request.data['flyer'] = image_data
-            else:
-                vErrors = inputValidator(request.data)
+            
+            vErrors = inputValidator(request.data)
         else:
             vErrors = inputValidator(request.data)
         

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -43,72 +43,73 @@ def apiUrlsList(request):
 # Purpose: View for GET, POST resources
 # Functionality: create new resource, retrieve all resources with given query params
 #
+
+def inputValidator(data):
+    # dict of list matches the format of serializer.errors
+    errorCatalog = defaultdict(list)
+
+    if data['startDate'] and data['endDate'] and data['startDate'] > data['endDate']:
+        errorCatalog['startDate'].append('Start date must occur after end date.')
+
+    nowStr = datetime.now().strftime('%Y-%m-%d')
+    if data['startDate'] and data['startDate'] < nowStr:
+        errorCatalog['startDate'].append('Start date must occur in the future.')
+
+    if data['startTime'] and data['endTime'] and data['startTime'] > data['endTime']:
+        errorCatalog['startDate'].append('Start time must occur before end time.')
+
+    if data['location'] != {} and data['location'] and len(data['location']['zip_code']) != 5 and len(data['location']['zip_code']) != 0:
+        # matching format of error in foreign key field
+        errorCatalog['location'] = {}
+        errorCatalog['location']['zip_code'] = ['Invalid zipcode.']
+
+    dataURLPattern = r"data:.+;base64,"
+    if data['flyer'] != None and not re.match(dataURLPattern, data['flyer']):
+        errorCatalog['flyer'].append('Data URL for `flyer` is either missing or invalid.')
+
+    correctDataURLStart = 'data:image'
+    if data['flyer'] != None and not correctDataURLStart == data['flyer'][:len(correctDataURLStart)]:
+        errorCatalog['flyer'].append('The flyer is not a valid image.')
+
+    phoneNumberPattern = r"^[0-9]*$"
+    if data['phone'] != None and not re.match(phoneNumberPattern, data['phone']):
+        errorCatalog['phone'].append('Phone numbers must only contain digits')
+
+    return dict(errorCatalog)
+
+def fillRequestBlanks(data, optionalsToDefaults):
+    for (fieldName,defaultVal) in optionalsToDefaults.items():
+        if not fieldName in data or data[fieldName] == "":
+            data[fieldName] = defaultVal
+
+def mergeFieldErrors(vErrors, sErrors):
+    result = sErrors
+    for (vFieldName,vFieldErrors) in vErrors.items():
+        if vFieldName == 'location':
+            # recursively merge location errors, since it is a foreign key field
+            sLocationErrors = sErrors['location'] if 'location' in sErrors else {}
+            result['location'] = mergeFieldErrors(vFieldErrors, sLocationErrors)
+        else:
+            # combine both lists of errors
+            sFieldErrors = sErrors[vFieldName] if vFieldName in sErrors else []
+            result[vFieldName] = sFieldErrors + vFieldErrors
+
+    return result
+
 class ResourceListCreate(ListCreateAPIView):
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer
     filter_backends = (DjangoFilterBackend, SearchFilter)
     filter_fields = ('id',)
     search_fields = ('name', 'organization',)
-
+    
     # All unrequired fields are populated with None values if empty
     defaultOptionalVals = { 'flyer': None, 'meetingLink': None, 'location': {}, 'flyerId': None, 'startDate': None, 'endDate': None, 'link': None, 'startTime': None, 'endTime': None, 'phone': None, 'email': None, 'isRecurring': None, 'recurrenceDays': [] }
 
-    def inputValidator(self, data):
-        # dict of list matches the format of serializer.errors
-        errorCatalog = defaultdict(list)
-
-        if data['startDate'] and data['endDate'] and data['startDate'] > data['endDate']:
-            errorCatalog['startDate'].append('Start date must occur after end date.')
-
-        nowStr = datetime.now().strftime('%Y-%m-%d')
-        if data['startDate'] and data['startDate'] < nowStr:
-            errorCatalog['startDate'].append('Start date must occur in the future.')
-
-        if data['startTime'] and data['endTime'] and data['startTime'] > data['endTime']:
-            errorCatalog['startDate'].append('Start time must occur before end time.')
-
-        if data['location'] != {} and data['location'] and len(data['location']['zip_code']) != 5 and len(data['location']['zip_code']) != 0:
-            # matching format of error in foreign key field
-            errorCatalog['location'] = {}
-            errorCatalog['location']['zip_code'] = ['Invalid zipcode.']
-
-        dataURLPattern = r"data:.+;base64,"
-        if data['flyer'] != None and not re.match(dataURLPattern, data['flyer']):
-            errorCatalog['flyer'].append('Data URL for `flyer` is either missing or invalid.')
-
-        correctDataURLStart = 'data:image'
-        if data['flyer'] != None and not correctDataURLStart == data['flyer'][:len(correctDataURLStart)]:
-            errorCatalog['flyer'].append('The flyer is not a valid image.')
-
-        phoneNumberPattern = r"^[0-9]*$"
-        if data['phone'] != None and not re.match(phoneNumberPattern, data['phone']):
-            errorCatalog['phone'].append('Phone numbers must only contain digits')
-
-        return dict(errorCatalog)
-
-    def fillRequestBlanks(self, data, optionalsToDefaults):
-        for (fieldName,defaultVal) in optionalsToDefaults.items():
-            if not fieldName in data or data[fieldName] == "":
-                data[fieldName] = defaultVal
-
-    def mergeFieldErrors(self, vErrors, sErrors):
-        result = sErrors
-        for (vFieldName,vFieldErrors) in vErrors.items():
-            if vFieldName == 'location':
-                # recursively merge location errors, since it is a foreign key field
-                sLocationErrors = sErrors['location'] if 'location' in sErrors else {}
-                result['location'] = self.mergeFieldErrors(vFieldErrors, sLocationErrors)
-            else:
-                # combine both lists of errors
-                sFieldErrors = sErrors[vFieldName] if vFieldName in sErrors else []
-                result[vFieldName] = sFieldErrors + vFieldErrors
-
-        return result
-
     # creates new resource
     def create(self, request, *args, **kwargs):
-        self.fillRequestBlanks(request.data, self.defaultOptionalVals)
-        vErrors = self.inputValidator(request.data)
+        fillRequestBlanks(request.data, defaultOptionalVals)
+        vErrors = inputValidator(request.data)
 
         #---- retrieve geoCoordinates
         if 'location' in request.data and request.data['location']:
@@ -348,6 +349,24 @@ class ResourceRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
         return response
 
     def update(self, request, *args, **kwargs):
+
+        # All unrequired fields are populated with None values if empty
+        defaultOptionalVals = { 'flyer': None, 'meetingLink': None, 'location': {}, 'flyerId': None, 'startDate': None, 'endDate': None, 'link': None, 'startTime': None, 'endTime': None, 'phone': None, 'email': None, 'isRecurring': None, 'recurrenceDays': [] }
+
+        fillRequestBlanks(request.data, defaultOptionalVals)
+
+        # Check whether image is base64
+        dataURLPattern = r"data:.+;base64,"
+        correctDataURLStart = 'data:image'
+        isbase64 = re.match(dataURLPattern, request.data['flyer']) and correctDataURLStart == request.data['flyer'][:len(correctDataURLStart)]
+
+        if not isbase64:
+            image_data = request.data.pop('flyer')
+            vErrors = inputValidator(request.data)
+            request.data['flyer'] = image_data
+        else:
+            vErrors = inputValidator(request.data)
+
         #---- retrieve geoCoordinates
         if 'location' in request.data and request.data['location']:
             address = request.data['location']
@@ -357,8 +376,31 @@ class ResourceRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
                 request.data['location']['longitude'] = geoCoordinates['lng']
         else:
             request.data['location'] = {}
+        
+        if isbase64 != None and isbase64:
+            # delete old image and add new one
+            if request.data['flyerId']:
+                cloudinary_delete(request.data['flyerId'])
+            
+            image = request.data['flyer']
+            # print(image)
+            print(vErrors)
+            
+            if image != None:
+                image = cloudinary_url(image)
+                request.data['flyer'] = image["url"]
+                request.data['flyerId'] = image["public_id"]
+
+        # Delete image
+        if not request.data['flyer'] and flyerId:
+            cloudinary_delete(request.data['flyerId'])
+            request.data['flyerId'] = ''
+            request.data['flyer'] = ''
 
         response = super().update(request, *args, **kwargs)
+
+        if response.status_code == 400:
+            return Response(vErrors, status=status.HTTP_400_BAD_REQUEST)
 
         if response.status_code == 200:
             from django.core.cache import cache

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -372,16 +372,21 @@ class ResourceRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
         
         # Handle new resource images
         if isbase64 != None and isbase64:
-            # delete old image and add new one
+            # delete old flyer image if it exists
             if request.data['flyerId']:
                 cloudinary_delete(request.data['flyerId'])
-            
+
+            # add new flyer image to resource
             image = request.data['flyer']
-            
             if image != None:
                 image = cloudinary_url(image)
                 request.data['flyer'] = image["secure_url"]
                 request.data['flyerId'] = image["public_id"]
+
+        # Delete existing image if flyer value in non
+        if request.data['flyer'] == None and request.data['flyerId']:
+            cloudinary_delete(request.data['flyerId'])
+            request.data['flyerId'] = None
 
         #---- retrieve geoCoordinates
         if 'location' in request.data and request.data['location']:


### PR DESCRIPTION
# Backend - Handling Images in PUT Request

## Summary
- Added capabilities to add a new flyer to an existing resource
- Added capabilities to replace a new flyer to an existing resource that already had a flyer previously
- Added capabilities to remove a flyer from an existing resource
- Moved validation code outside create class in order for PUT request to access validation methods (Ideally this would be in a separate file and be imported but time was not on out side)

## Notes
Actions are very dependent on the API data only altering the data that they wish to replace. For example, when replacing a flyer the flyerId of the previous flyer must be passed in with the new base64 encoded image in order for the old image to be deleted successfully. This is similar for deleting an image, the flyerId of the previous image must be passed in order to delete the existing flyer image.

## Testing
- Postman
    - Tested adding new images to resources without them
    -  Tested replacing flyer images of varying sizes
    - Tested deleting an image with an already existing flyer